### PR TITLE
CC-16902 Backport for added additional validation to form fields.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "require": {
     "php": ">=7.1",
     "spryker/cms-block": "^1.3.0",
-    "spryker/gui": "^3.3.3",
+    "spryker/gui": "^3.47.2",
     "spryker/kernel": "^3.0.0",
     "spryker/locale": "^3.0.0",
     "spryker/propel-orm": "^1.0.0",

--- a/src/Spryker/Zed/CmsBlockGui/Communication/Form/Glossary/CmsBlockGlossaryPlaceholderTranslationForm.php
+++ b/src/Spryker/Zed/CmsBlockGui/Communication/Form/Glossary/CmsBlockGlossaryPlaceholderTranslationForm.php
@@ -89,6 +89,9 @@ class CmsBlockGlossaryPlaceholderTranslationForm extends AbstractType
             'constraints' => [
                 $this->getFactory()->createTwigContentConstraint(),
             ],
+            'sanitize_xss' => true,
+            'allowed_attributes' => ['style'],
+            'allowed_html_tags' => ['iframe'],
         ]);
 
         return $this;


### PR DESCRIPTION
- Branch: backport/1.1.10
- Ticket: https://spryker.atlassian.net/browse/CC-16902
- Version: 1.1.10
- Strategy: minor

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   CmsBlockGui           | patch                 | Gui                   |
   
-----------------------------------------

#### Module CmsBlockGui

##### Change log

Fixes

- Adjusted `CmsBlockGlossaryPlaceholderTranslationForm` to sanitize the `translation` field.
- Impacted `EditGlossaryController::indexAction()` with these changes.
- Increased `Gui` dependency version.